### PR TITLE
不要なファイルを生成しない

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@
 
 # Ignore Byebug command history file.
 .byebug_history
+public/uploads/*

--- a/config/application.rb
+++ b/config/application.rb
@@ -8,8 +8,11 @@ Bundler.require(*Rails.groups)
 
 module FreemarketSample48b
   class Application < Rails::Application
-    # Settings in config/environments/* take precedence over those specified here.
-    # Application configuration should go into files in config/initializers
-    # -- all .rb files in that directory are automatically loaded.
+    config.generators do |g|
+      g.stylesheets false
+      g.javascripts false
+      g.helper false
+      g.test_framework false
+    end
   end
 end


### PR DESCRIPTION
＃What
画像がGithubにコミットされない
不要なファイルを生成しない

#Why
プルリク等した際に余計に見るものが増えるため