### PR TITLE
出品の為の修正

### DIFF
--- a/app/models/product.rb
+++ b/app/models/product.rb
@@ -6,7 +6,7 @@ has_many :images
 accepts_nested_attributes_for :images
 belongs_to :user
 belongs_to :category
-belongs_to :brand
+belongs_to :brand, foreign_key: "brand_id", optional: true
 enum status: {
   sell: 0, sold: 1, soldout: 2
 }, _prefix: true


### PR DESCRIPTION
foreign_key: "brand_id", optional: trueを消してしまって商品出品できなくなってしまっていた。